### PR TITLE
cdn-open-api

### DIFF
--- a/src/Service/Cdn.php
+++ b/src/Service/Cdn.php
@@ -102,6 +102,18 @@ class Cdn extends V4Curl
                 ],
             ],
         ],
+		//设置域名详细配置信息
+        'SetDomainConfigs' => [
+            'url' => '/2016-09-01/domain/SetDomainConfigs',
+            'method' => 'post',
+            'config' => [
+                'headers' => [
+                    'X-Version' => '2016-09-01',
+                    'X-Action' => 'SetDomainConfigs',
+					'content-type' => 'application/json',
+                ],
+            ],
+        ],
         //设置过滤参数功能
         'SetIgnoreQueryStringConfig' => [
             'url' => '/2016-09-01/domain/SetIgnoreQueryStringConfig',
@@ -569,7 +581,40 @@ class Cdn extends V4Curl
                 ],
             ],
         ],
-
+		//泛域名统计接口
+		//泛域名明细带宽查询
+		'GetSubDomainsBandwidthData' => [
+            'url' => '/2016-09-01/statistics/GetSubDomainsBandwidthData',
+            'method' => 'get',
+            'config' => [
+                'headers' => [
+                    'X-Version' => '2016-09-01',
+                    'X-Action' => 'GetSubDomainsBandwidthData',
+                ],
+            ],
+        ],
+		//泛域名明细流量查询
+		'GetSubDomainsFlowData' => [
+            'url' => '/2016-09-01/statistics/GetSubDomainsFlowData',
+            'method' => 'get',
+            'config' => [
+                'headers' => [
+                    'X-Version' => '2016-09-01',
+                    'X-Action' => 'GetSubDomainsFlowData',
+                ],
+            ],
+        ],
+		//泛域名明细请求数查询
+		'GetSubDomainsPvData' => [
+            'url' => '/2016-09-01/statistics/GetSubDomainsPvData',
+            'method' => 'get',
+            'config' => [
+                'headers' => [
+                    'X-Version' => '2016-09-01',
+                    'X-Action' => 'GetSubDomainsPvData',
+                ],
+            ],
+        ],
         // 内容管理接口
         /**
          * 刷新接口
@@ -609,6 +654,7 @@ class Cdn extends V4Curl
                 'headers' => [
                     'X-Version' => '2016-09-01',
                     'X-Action' => 'GetRefreshOrPreloadTask',
+					'content-type' => 'application/json',
                 ],
             ],
         ],
@@ -762,7 +808,31 @@ class Cdn extends V4Curl
                     'X-Action' => 'GetCertificates',
                 ],
             ],
-        ]
+        ],
+		//辅助工具
+        /**
+         * 根据源站地址获取加速域名
+         */
+        'GetDomainsByOrigin' => [
+            'url' => '/2016-09-01/domain/GetDomainsByOrigin',
+            'method' => 'get',
+            'config' => [
+                'headers' => [
+                    'X-Version' => '2016-09-01',
+                    'X-Action' => 'GetDomainsByOrigin',
+                ],
+            ],
+        ],
+        'GetCnameSuffixs' => [
+            'url' => '/2016-09-01/domain/GetCnameSuffixs',
+            'method' => 'get',
+            'config' => [
+                'headers' => [
+                    'X-Version' => '2016-09-01',
+                    'X-Action' => 'GetCnameSuffixs',
+                ],
+            ],
+        ],		
     ];
 
     //特殊封装  request

--- a/tests/CdnTest.php
+++ b/tests/CdnTest.php
@@ -1391,6 +1391,7 @@ class CdnTest extends \PHPUnit_Framework_TestCase
                 'EndTime' => '2017-02-28T23:56+0800',
                 'CdnType' => 'download',
                 'Regions' => 'CN,AS,NA,AU',
+				'ProtocolType' =>'http',
             ],
         ];
         $response = Cdn::getInstance()->request('GetPeakBandwidthData', $params);

--- a/tests/CdnTest.php
+++ b/tests/CdnTest.php
@@ -51,7 +51,7 @@ class CdnTest extends \PHPUnit_Framework_TestCase
     {
         $params = [
             'query' => [
-                'DomainName' => 'www.le.com',     //加速域名
+                'DomainName' => 'www.le.com',     //加速域名,可输入泛域名*.le.com
                 'CdnType' => 'download',    //加速类型
                 'CdnProtocol' => 'http',    //客户访问边缘节点的协议。默认http
                 'Regions' => 'CN', //加速区域，默认CN， 可以输入多个，以逗号间隔。
@@ -59,6 +59,7 @@ class CdnTest extends \PHPUnit_Framework_TestCase
                 'OriginProtocol' => 'http', //回源协议
                 'Origin' => 'www.ksyun.com',    //源站域名
                 'OriginPort' => '80', //源站域名端口号
+				'SearchUrl' => 'www.le.backsource.com/test.html',//泛域名时，必输,非泛域名时填写无效
             ],
         ];
         $response = Cdn::getInstance()->request('AddCdnDomain', $params);
@@ -97,6 +98,7 @@ class CdnTest extends \PHPUnit_Framework_TestCase
                 'OriginType' => 'domain', //源站类型
                 'OriginPort' => '80', //源站域名端口号
                 //'Regions' => '', //加速区域，默认CN
+				'SearchUrl' => 'www.le.backsource.com/test.html'//泛域名时，可输,非泛域名时填写无效
             ],
         ];
         $response = Cdn::getInstance()->request('ModifyCdnDomain', $params);
@@ -158,6 +160,26 @@ class CdnTest extends \PHPUnit_Framework_TestCase
         ];
         $response = Cdn::getInstance()->request('GetDomainConfigs', $params);
         return $this->assertEquals($response->getStatusCode(), 200);
+    }
+	/**
+     * 多项域名配置信息修改
+     */
+    public function testSetDomainConfigs()
+    {   
+	    /*参数说明
+            DomainId    域名ID
+            IgnoreQueryStringConfig               表示设置过滤参数
+            BackOriginHostConfig       表示设置回源host
+            ReferProtectionConfig      	表示设置refer防盗链
+            CacheRuleConfig         表示设置缓存策略
+            IpProtectionConfig      表示设置IP防盗链
+        */
+        $data = "{\"DomainId\":\"2D09NA6\",\"CacheRuleConfig\":{\"CacheRules\":[{\"CacheRuleType\":\"directory\",\"Value\":\"/XXX/\",\"CacheTime\":11,\"RespectOrigin\":\"off\"},{\"CacheRuleType\":\"exact\",\"Value\":\"/XXX/XXX.TXT,/sdfsf/sdf.text\",\"CacheTime\":120,\"RespectOrigin\":\"off\"}]},\"IgnoreQueryStringConfig\":{\"Enable\":\"on\"},\"ReferProtectionConfig\":{\"Enable\":\"on\",\"ReferType\":\"block\",\"ReferList\":\"www.baidu.com,www.sina.com\",\"AllowEmpty\":\"on\"},\"BackOriginHostConfig\":{\"BackOriginHost\":\"www.a.qunar.com\"},\"IpProtectionConfig\":{\"Enable\":\"on\",\"IpType\":\"allow\",\"IpList\":\"10.1.1.1\"}}";
+        $params = [
+            'body' => $data,
+        ];
+        $response = Cdn::getInstance()->request('SetDomainConfigs', $params);
+        return $this->assertEquals($response->getStatuscode(), 200);
     }
 
     /**
@@ -1224,12 +1246,11 @@ class CdnTest extends \PHPUnit_Framework_TestCase
      * Type	否	String	任务类别，取值为：refresh，刷新任务；取值为:preload,预热任务
      */
     public function testGetRefreshOrPreloadTask()
-    {
+    {	
+		$data = "{\"StartTime\":\"2016-11-19T08:00+0800\",\"EndTime\":\"2016-11-20T08:00+0800\",\"TaskId\":\"4da8be59-495d-41a6-8b35-733815aea33f\",\"Urls\": [{\"Url\": \"http:\/\/www.zhaofang360.com\/abc.txt\"},{\"Url\": \"http:\/\/www.zhaofang360.com\/test\"}],\"PageSize\":50,\"PageNumber\":1,\"Type\":\"refresh\"}";
+		
         $params = [
-            'query' => [
-                'StartTime' => '2016-11-19T08:00+0800',
-                'EndTime' => '2016-11-20T08:00+0800',
-            ],
+            'body' => $data,
         ];
         $response = Cdn::getInstance()->request('GetRefreshOrPreloadTask', $params);
         return $this->assertEquals($response->getStatuscode(), 200);
@@ -1372,7 +1393,79 @@ class CdnTest extends \PHPUnit_Framework_TestCase
         $response = Cdn::getInstance()->request('GetPeakBandwidthData', $params);
         return $this->assertEquals($response->getStatuscode(), 200);
     }
-
+	/**
+	 *泛域名明细带宽查询
+	 *查询泛域名下次级域名的详细带宽数据，进行数据保存以及数据分析
+	 */
+	
+	public function testGetSubDomainsBandwidthData()
+    {
+        $params = [
+            'query' => [
+			    'DomainId' => '2D099E6',
+				'Domains' => 'www.cmcm.com,A.cmcm.com',
+				'Granularity' => '5',
+                'StartTime' => '2017-11-06T00:00+0800',
+                'EndTime' => '2017-11-06T00:05+0800',
+                'ResultType' => 1,
+				'DataType' => 'origin,edge',
+				'ProtocolType' => 'http',
+                'Regions' => 'CN,AS,NA,AU',
+            ],
+        ];
+        $response = Cdn::getInstance()->request('GetSubDomainsBandwidthData', $params);
+        return $this->assertEquals($response->getStatuscode(), 200);
+    }
+	/**
+	 *泛域名查询流量
+	 *获取泛域名次级域名流量数据，包括边缘流量、回源流量数据，
+	 *查询单个域名或多域名合并后实时流量数据，用于绘制一条流量线图
+	 */
+	
+	public function testGetSubDomainsFlowData()
+    {
+        $params = [
+            'query' => [
+			    'DomainId' => '2D099E6',
+				'Domains' => 'www.cmcm.com,A.cmcm.com',
+				'Granularity' => '5',
+                'StartTime' => '2017-11-06T00:00+0800',
+                'EndTime' => '2017-11-06T00:05+0800',
+                'ResultType' => 1,
+				'DataType' => 'origin,edge',
+				'ProtocolType' => 'http',
+                'Regions' => 'CN,AS,NA,AU',
+            ],
+        ];
+        $response = Cdn::getInstance()->request('GetSubDomainsFlowData', $params);
+        return $this->assertEquals($response->getStatuscode(), 200);
+    }
+	
+	/**
+	 *泛域名请求数查询
+	 *获取泛域名次级域名请求数数据，包括边缘请求数、回源请求数数据
+	 *查询单个域名或多域名合并后实时请求数数据，用于绘制一条请求数线图
+	 */
+	
+	public function testGetSubDomainsPvData()
+    {
+        $params = [
+            'query' => [
+			    'DomainId' => '2D099E6',
+				'Domains' => 'www.cmcm.com,A.cmcm.com',
+				'Granularity' => '5',
+                'StartTime' => '2017-11-06T00:00+0800',
+                'EndTime' => '2017-11-06T00:05+0800',
+                'ResultType' => 1,
+				'DataType' => 'origin,edge',
+				'ProtocolType' => 'http',
+                'Regions' => 'CN,AS,NA,AU',
+            ],
+        ];
+        $response = Cdn::getInstance()->request('GetSubDomainsPvData', $params);
+        return $this->assertEquals($response->getStatuscode(), 200);
+    }
+	
     /**
      * 屏蔽、解除屏蔽URL。支持json和xml两种格式
      */
@@ -1613,7 +1706,33 @@ class CdnTest extends \PHPUnit_Framework_TestCase
         $response = Cdn::getInstance()->request('GetCertificates', $params);
         return $this->assertEquals($response->getStatuscode(), 200);
     }
-
+	//辅助工具
+	/**
+	*根据源站地址获取加速域名
+	*/
+    public function testGetDomainsByOrigin()
+    {
+        $params = [
+            'query' => [
+                'Origin' => '10.11.0.27', //指定的源站地址，包括IP源站和域名源站
+            ],
+        ];
+        $response = Cdn::getInstance()->request('GetDomainsByOrigin', $params);
+		print $response->getBody();
+        return $this->assertEquals($response->getStatusCode(), 200);
+    }
+	/**
+    * 获取厂商CNAME后缀
+    */
+    public function testGetCnameSuffixs()
+    {
+        $params = [
+            'query' => [
+            ],
+        ];
+        $response = Cdn::getInstance()->request('GetCnameSuffixs', $params);
+        return $this->assertEquals($response->getStatusCode(), 200);
+    } 
 }
 
 

--- a/tests/CdnTest.php
+++ b/tests/CdnTest.php
@@ -392,6 +392,7 @@ class CdnTest extends \PHPUnit_Framework_TestCase
                 'ResultType' => '0', //带宽数据返回类型  0：多域名多区域数据做合并；1：每个域名每个区域的数据分别返回
                 'Regions' => 'CN', //查询区域
                 'DataType' => 'origin', //数据类型,边缘或者回源 edge:边缘数据; origin:回源数据
+				'ProtocolType' => 'http',
             ],
         ];
         $response = Cdn::getInstance()->request('GetBandwidthData', $params);
@@ -421,6 +422,7 @@ class CdnTest extends \PHPUnit_Framework_TestCase
                 'ResultType' => '0', //带宽数据返回类型  0：多域名多区域数据做合并；1：每个域名每个区域的数据分别返回
                 'Regions' => 'CN', //查询区域
                 'DataType' => 'edge', //数据类型,边缘或者回源 edge:边缘数据; origin:回源数据
+				'ProtocolType' => 'http',
             ],
         ];
         $response = Cdn::getInstance()->request('GetFlowData', $params);
@@ -457,6 +459,7 @@ class CdnTest extends \PHPUnit_Framework_TestCase
                 'DataType' => 'edge',
                 'Granularity' => '5', //统计粒度 取值为 5（默认）：5分钟粒度；10：10分钟粒度；20：20分钟粒度；60：1小时粒度；
                 //240：4小时粒度；480：8小时粒度；1440：1天粒度；以上粒度均取该粒度时间段的请求数总和
+				'ProtocolType' => 'http',
             ],
         ];
         $response = Cdn::getInstance()->request('GetPvData', $params);


### PR DESCRIPTION
1、获取厂商CNAME后缀：GetCnameSuffixs
2、根据源站地址获取加速域名：GetDomainsByOrigin
3、泛域名请求数查询：GetSubDomainsPvData
4、泛域名查询流量：GetSubDomainsFlowData
5、泛域名明细带宽查询：GetSubDomainsBandwidthData
6、多项域名配置信息修改：SetDomainConfigs
以上接口新接入sdk
1、新增域名：AddCdnDomain 
2、查询域名基础信息：GetCdnDomainBasic
3、修改域名基本配置：ModifyCdnDomain
以上接口兼容泛域名需求，修改